### PR TITLE
support tildes in paths

### DIFF
--- a/mirt/mirt_util.py
+++ b/mirt/mirt_util.py
@@ -634,8 +634,8 @@ def get_normalized_time(time, min_time=1, max_time=100, log_time=True):
 
 
 def data_to_json(theta, exercise_ind_dict, max_time_taken, outfilename,
-                 slug='Test', title='test parameters', description='parameters'
-                 'for an adaptive test'):
+                 slug='Test', title='test parameters',
+                 description='parameters for an adaptive test'):
     """Convert a set of mirt parameters into a json file and write it"""
 
     out_data = {

--- a/start_mirt_pipeline.py
+++ b/start_mirt_pipeline.py
@@ -126,6 +126,16 @@ def get_command_line_arguments(arguments=None):
     else:
         arguments = parser.parse_args()
 
+    # Support file paths in the form of "~/blah", which python
+    # doesn't normally recognise
+    if arguments.data_file:
+        arguments.data_file = os.path.expanduser(arguments.data_file)
+    if arguments.model_directory:
+        arguments.model_directory = os.path.expanduser(
+                arguments.model_directory)
+    if arguments.model:
+        arguments.model = os.path.expanduser(arguments.model)
+
     # When visualize is true, we do all visualizations
     if arguments.visualize:
         arguments.roc_viz = True


### PR DESCRIPTION
Python doesn't handle '~/blah' style paths very well when they're passed in from the commandline. This will prevent guacamole from crashing when writing out to paths in this format.