### PR TITLE
Make datetime format compatible with Windows file systems.

### DIFF
--- a/start_mirt_pipeline.py
+++ b/start_mirt_pipeline.py
@@ -152,7 +152,8 @@ def get_command_line_arguments(arguments=None):
         parser.print_help()
 
     # Save the current time for reference when looking at generated models.
-    arguments.datetime = str(datetime.datetime.now())
+    DATE_FORMAT = '%Y-%m-%d-%H-%M-%S'
+    arguments.datetime = str(datetime.datetime.now().strftime(DATE_FORMAT))
 
     return arguments
 


### PR DESCRIPTION
I'm not sure the best way to add that format string constant.

It works because `:` is an invalid character in Windows files.